### PR TITLE
Eliminate memory leak

### DIFF
--- a/_Common/InitializeLibrary.cpp
+++ b/_Common/InitializeLibrary.cpp
@@ -234,9 +234,6 @@ void APDFLib::fillDirectories() {
     CFRelease(baseURL);
     CFRelease(resourceURL);
 
-    char **tmpP = NULL;
-    tmpP = (char **)malloc(sizeof(char *) * NO_OF_RESOURCE_DIR);
-
     char fontPath[NO_OF_RESOURCE_DIR][MAX_PATH];
     for (int i = 0; i < NO_OF_RESOURCE_DIR; i++) {
         strncpy_safe(fontPath[i], sizeof(fontPath[i]), resourceDirectory, sizeof(resourceDirectory));


### PR DESCRIPTION
tmpP is never used anywhere in the code, and is never freed. It seems to have been introduced with a blind copy and paste from somewhere else.