### PR TITLE
Fix overflow issue.

### DIFF
--- a/Images/RenderPage/RenderPage.cpp
+++ b/Images/RenderPage/RenderPage.cpp
@@ -1,8 +1,6 @@
 //
 // Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
 //
-// The RenderPage sample program shows how to render a PDF document page to memory.
-//
 
 #include "RenderPage.h"
 #include <math.h>
@@ -259,7 +257,7 @@ RenderPage::RenderPage(PDPage &pdPage, const char *colorSpace, const char *filte
     // To remedy this difference, we check to see if the 32-bit aligned width
     // is different from the 8-bit aligned width. If so, we fix the image data by
     // stripping off the padding at the end of each row.
-    ASInt32 createdWidth = ((((attrs.width * bpc * nComps) + 31) / 32) * 4);
+    ASUns32 createdWidth = ((((attrs.width * bpc * nComps) + 31) / 32) * 4);
 
     // For 1bpc, because our pixels are packed into a size smaller than how each sample
     // is represented we need to account for possibly the next byte of data in our width.
@@ -268,7 +266,7 @@ RenderPage::RenderPage(PDPage &pdPage, const char *colorSpace, const char *filte
         packing = ((attrs.width % 8) != 0) ? 1 : 0;
     }
 
-    ASInt32 desiredWidth = ((attrs.width * bpc * nComps) / 8) + packing;
+    ASUns32 desiredWidth = ((attrs.width * bpc * nComps) / 8) + packing;
 
     if (createdWidth != desiredWidth) {
         for (int row = 1; row < attrs.height; row++)


### PR DESCRIPTION
For very large images the product used as the buffer index can exceed the int type which will become a negative value and cause a crash, use an unsigned int.