### PR TITLE
Set Flate effort for best performance.

### DIFF
--- a/Images/RenderPage/RenderPage.h
+++ b/Images/RenderPage/RenderPage.h
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017-2023, Datalogics, Inc. All rights reserved.
+// Copyright (c) 2017-2024, Datalogics, Inc. All rights reserved.
 //
 // Sample: RenderPage
 //
@@ -36,6 +36,7 @@ class RenderPage {
 
     ASFixedRect imageSize; // This will carry the image size in PDF units.
 
+    PDEFilterArray SetFlateFilterParams(CosDoc cosDoc);
     PDEFilterArray SetDCTFilterParams(CosDoc cosDoc);
     PDEFilterArray SetCCITTFaxFilterParams(CosDoc cosDoc);
     ASAtom SetColorSpace(const char *colorSpace);

--- a/Images/RenderPage/mainproc.cpp
+++ b/Images/RenderPage/mainproc.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+// Copyright (c) 2007-2024, Datalogics, Inc. All rights reserved.
 //
 // Sample: RenderPage - Demonstrates the process of rasterizing the cropped area of a PDF page
 //   and placing the resulting raster as an image into a different PDF document.


### PR DESCRIPTION
As a best practice for our rasterization sample, set the Flate effort accordingly.