### PR TITLE
Fix a couple things.

### DIFF
--- a/Images/OutputPreview/OutputPreview.cpp
+++ b/Images/OutputPreview/OutputPreview.cpp
@@ -205,7 +205,10 @@ int main(int argc, char *argv[]) {
 
                 // Release the buffer for the last bitmap drawn
                 if (pageInfo.drawParams.buffer != NULL)
+                {
                     ASfree(pageInfo.drawParams.buffer);
+                    pageInfo.drawParams.buffer = NULL;
+                }
             }
 
             // Release the page.
@@ -311,9 +314,9 @@ void FillPageInfo(PageInfo *pageInfo, PDPage page) {
     pageInfo->drawParams.asRealDestRect = &pageInfo->drawWindow;
     pageInfo->drawParams.bpc = 8;
 
-    // If we want to control other effects during rendering, it can be done here. In general though
-    //   only lazyErase is used.
-    pageInfo->drawParams.flags = kPDPageDoLazyErase;
+    // Because Spot Colorants may only be part of Annotation appearances, to do a proper DeviceN rendering
+    // of all colorants this needs to be set.
+    pageInfo->drawParams.flags = kPDPageDoLazyErase | kPDPageUseAnnotFaces;
 
     // When doing separations, we NEVER want Anti-Aliasing!
     pageInfo->drawParams.smoothFlags = 0;


### PR DESCRIPTION
As part of creating the DeviceN image we were always freeing the buffer if it wasn't null, just set it to null after freeing it in the loop to avoid a double free for multipage input.

Because Spot Colorants may only be part of Annotation appearances, to do a proper DeviceN rendering of all colorants this needs to be set. Otherwise we collect all the spot colorants including those of Annotation appearances and setup our DeviceN rendering with it....but at the same time we tell PDFL with our render flags "don't consider them", leading to scrambled output.