### PR TITLE
SF47123 - Change to avoid a problem of embedding different fonts sharing the same Descriptor.

### DIFF
--- a/ContentModification/EmbedFonts/EmbedFonts.cpp
+++ b/ContentModification/EmbedFonts/EmbedFonts.cpp
@@ -163,6 +163,27 @@ ACCB1 ASBool ACCB2 GetFontInfoProc(PDFont pdFont, PDFontFlags* fontFlags, std::v
             UnembeddedFont fontToBeEmbedded;
             fontToBeEmbedded.cosObj = PDFontGetCosObj(pdFont);
 
+            // Sometimes fonts share the same /FontDesctriptor, if we're embedding a new Font Program and
+            // the Descriptor happens to be re-used then it may not work as intended for the _other_ font.
+            // To avoid problems make each FontDescriptor a new object so it's no longer shared with others.
+            CosObj parentOfFontDescriptor = CosNewNull();
+            CosObj fontDescriptorObj = CosNewNull();
+
+            if (attrs.type == ASAtomFromString("Type0")) {
+                CosObj descendantFonts = CosDictGet(fontToBeEmbedded.cosObj, ASAtomFromString("DescendantFonts"));
+                if (CosObjGetType(descendantFonts) == CosArray && CosArrayLength(descendantFonts) == 1) {
+                    parentOfFontDescriptor = CosArrayGet(descendantFonts, 0);
+
+                    fontDescriptorObj = CosDictGet(parentOfFontDescriptor, ASAtomFromString("FontDescriptor"));
+                }
+            }
+            else {
+                parentOfFontDescriptor = fontToBeEmbedded.cosObj;
+                fontDescriptorObj = CosDictGet(parentOfFontDescriptor, ASAtomFromString("FontDescriptor"));
+            }
+
+            CosDictPut(parentOfFontDescriptor, ASAtomFromString("FontDescriptor"), CosObjCopy(fontDescriptorObj, CosObjGetDoc(fontDescriptorObj), true));
+
             clientData.push_back(fontToBeEmbedded);
         }
     HANDLER

--- a/ContentModification/EmbedFonts/EmbedFonts.cpp
+++ b/ContentModification/EmbedFonts/EmbedFonts.cpp
@@ -163,7 +163,7 @@ ACCB1 ASBool ACCB2 GetFontInfoProc(PDFont pdFont, PDFontFlags* fontFlags, std::v
             UnembeddedFont fontToBeEmbedded;
             fontToBeEmbedded.cosObj = PDFontGetCosObj(pdFont);
 
-            // Sometimes fonts share the same /FontDesctriptor, if we're embedding a new Font Program and
+            // Sometimes fonts share the same /FontDescriptor, if we're embedding a new Font Program and
             // the Descriptor happens to be re-used then it may not work as intended for the _other_ font.
             // To avoid problems make each FontDescriptor a new object so it's no longer shared with others.
             CosObj parentOfFontDescriptor = CosNewNull();


### PR DESCRIPTION
Sometimes fonts share the same `/FontDescriptor`, if we're embedding a new Font Program and the Descriptor happens to be _re-_used then it may not work as intended for the _other_ font.

This can be dealt with in different ways (e.g. track seen FontDescriptors and replace if necessary or make a whole new Descriptor from scratch, etc.), but for the purposes of this sample which illustrates fairly advanced usage of PDFL, I've chosen to address it by making each FontDescriptor a _new_ object so it's no longer shared with others.