### PR TITLE
Upgrade to Xcode 16.4 on all Mac Platforms

### DIFF
--- a/dlproject.yaml
+++ b/dlproject.yaml
@@ -33,18 +33,18 @@ config:
     config:
       Release:
         profile_host:
-          - apple-clang-15.0-intel-cppstd-17
+          - apple-clang-16.4-intel-cppstd-17
         profile_build:
-          - apple-clang-15.0-intel-cppstd-17
+          - apple-clang-16.4-intel-cppstd-17
         build: missing
 
   macos-arm64:
     config:
       Release:
         profile_host:
-          - apple-clang-15.0-arm-cppstd-17
+          - apple-clang-16.4-arm-cppstd-17
         profile_build:
-          - apple-clang-15.0-arm-cppstd-17
+          - apple-clang-16.4-arm-cppstd-17
         build: missing
       LicenseManaged:
         include: Release


### PR DESCRIPTION
Upgrade to Xcode 16.4 on all Mac Platforms