### PR TITLE
[APDFL-6694] build: replace deprecated wmic with env vars in build_run_all.bat

### DIFF
--- a/All/build_run_all.bat
+++ b/All/build_run_all.bat
@@ -88,7 +88,15 @@ REM *************************************************
 REM *** Initialize environment variables, enable delayed expansion.
 SETLOCAL EnableDelayedExpansion  
 REM *** Filename of All project.
-FOR /f %%a IN ('wmic OS get OSArchitecture ^| findstr /r /v "^$"') DO SET "WIN_ARCH=%%a"
+REM *** Determine the OS architecture using built-in environment variables.
+REM *** PROCESSOR_ARCHITEW6432 is set when a 32-bit process runs on 64-bit Windows;
+REM *** in that case it reflects the true OS architecture. Otherwise PROCESSOR_ARCHITECTURE
+REM *** is the OS architecture. This replaces the deprecated `wmic` command.
+IF DEFINED PROCESSOR_ARCHITEW6432 (
+  SET "WIN_ARCH=%PROCESSOR_ARCHITEW6432%"
+) ELSE (
+  SET "WIN_ARCH=%PROCESSOR_ARCHITECTURE%"
+)
 IF NOT "x%WIN_ARCH:ARM=%"=="x%WIN_ARCH%" (
   REM Do an arm64 build
   SET ALL_DL_SLN=All_Datalogics_ARM64.sln


### PR DESCRIPTION
APDFL-6694: Detect OS architecture via PROCESSOR_ARCHITECTURE / PROCESSOR_ARCHITEW6432 instead of `wmic OS get OSArchitecture`, which is deprecated in recent Windows releases.

### Fixes Jira issue [APDFL-6694](https://datalogics-jira.atlassian.net/browse/APDFL-6694)

[APDFL-6694]: https://datalogics-jira.atlassian.net/browse/APDFL-6694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ