### PR TITLE
[APDFL-6694] Backport wmic-removal fix to develop-18 (build_run_all.bat)

### DIFF
--- a/All/build_run_all.bat
+++ b/All/build_run_all.bat
@@ -88,7 +88,15 @@ REM *************************************************
 REM *** Initialize environment variables, enable delayed expansion.
 SETLOCAL EnableDelayedExpansion  
 REM *** Filename of All project.
-FOR /f %%a IN ('wmic OS get OSArchitecture ^| findstr /r /v "^$"') DO SET "WIN_ARCH=%%a"
+REM *** Determine the OS architecture using built-in environment variables.
+REM *** PROCESSOR_ARCHITEW6432 is set when a 32-bit process runs on 64-bit Windows;
+REM *** in that case it reflects the true OS architecture. Otherwise PROCESSOR_ARCHITECTURE
+REM *** is the OS architecture. This replaces the deprecated `wmic` command.
+IF DEFINED PROCESSOR_ARCHITEW6432 (
+  SET "WIN_ARCH=%PROCESSOR_ARCHITEW6432%"
+) ELSE (
+  SET "WIN_ARCH=%PROCESSOR_ARCHITECTURE%"
+)
 IF NOT "x%WIN_ARCH:ARM=%"=="x%WIN_ARCH%" (
   REM Do an arm64 build
   SET ALL_DL_SLN=All_Datalogics_ARM64.sln


### PR DESCRIPTION
Backports `5f2809c` (Rob's `APDFL-6694` fix, already on `develop-21`) to `develop-18`. Nightly's `windows-apdfl-samples` 32-bit (`allen-win11`) and 64-bit (`gates-reborn`) legs fail because `build_run_all.bat` detects OS arch with wmic OS get `OSArchitecture`; wmic.exe was removed from recent Windows (`KB5067470`), so `WIN_ARCH` ends up empty and the following IF block collapses. This cherry-picks the exact env-var detection (`PROCESSOR_ARCHITEW6432`/`PROCESSOR_ARCHITECTURE`) that's been green in `develop-21` nightly for months.